### PR TITLE
OTS-303: Send Subscribero on the constructor

### DIFF
--- a/android/ScreensharingAccPackKit/screensharing-acc-pack-kit/src/main/java/com/tokbox/android/accpack/screensharing/ScreenSharingFragment.java
+++ b/android/ScreensharingAccPackKit/screensharing-acc-pack-kit/src/main/java/com/tokbox/android/accpack/screensharing/ScreenSharingFragment.java
@@ -391,7 +391,7 @@ public class ScreenSharingFragment extends Fragment implements AccPackSession.Se
    */
     public void enableRemoteAnnotations(boolean annotationsEnabled, AnnotationsToolbar toolbar, ViewGroup view, Subscriber subscriber) {
         //TODO connectionId from STREAM instead of sessioonconnectionId
-        AnnotationsView remoteAnnotationsView = new AnnotationsView(getContext(), mSession, mApiKey, false, AnnotationsView.ViewType.SubscriberView);
+        AnnotationsView remoteAnnotationsView = new AnnotationsView(getContext(), mSession, mApiKey, false, AnnotationsView.ViewType.SubscriberView, subscriber.getStream().getConnection().getConnectionId());
 
         AnnotationsVideoRenderer renderer = new AnnotationsVideoRenderer(getContext());
         subscriber.setRenderer(renderer);


### PR DESCRIPTION
@marinaserranomontes Please review this PR.

The change is basically to send the subscriber on the constructor so that the AnnotationsView can use the connectionId from the remote stream.

