### PR TITLE
[OTS-694] Using OTCommonCommunicator enums that replace OTMultiPartyS…

### DIFF
--- a/ios/ScreenShareAccPackKit/OTScreenShareKit.podspec
+++ b/ios/ScreenShareAccPackKit/OTScreenShareKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OTScreenShareKit"
-  s.version          = "2.0.0-beta4"
+  s.version          = "2.0.0-beta5"
   s.summary          = "OpenTok Screensharing with Annotations Accelerator Pack enables users to share their screens between mobile or browser-based devices."
 
   s.description      = "This document describes how to use the OpenTok Screensharing with Annotations Accelerator Pack for iOS. Through the exploration of the OpenTok Screensharing with Annotations Sample App, you will learn best practices for screensharing on an iOS mobile device."
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
 
   s.source_files = 'ios/ScreenShareAccPackKit/OTScreenShareKit/**/*'
 
-  s.dependency 'OTAcceleratorPackUtil', '~> 2.0.0-beta4'
+  s.dependency 'OTAcceleratorPackUtil', '~> 2.0.0-beta5'
 end

--- a/ios/ScreenShareAccPackKit/OTScreenShareKit.podspec
+++ b/ios/ScreenShareAccPackKit/OTScreenShareKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OTScreenShareKit"
-  s.version          = "2.0.0-beta5"
+  s.version          = "2.0.0"
   s.summary          = "OpenTok Screensharing with Annotations Accelerator Pack enables users to share their screens between mobile or browser-based devices."
 
   s.description      = "This document describes how to use the OpenTok Screensharing with Annotations Accelerator Pack for iOS. Through the exploration of the OpenTok Screensharing with Annotations Sample App, you will learn best practices for screensharing on an iOS mobile device."
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
 
   s.source_files = 'ios/ScreenShareAccPackKit/OTScreenShareKit/**/*'
 
-  s.dependency 'OTAcceleratorPackUtil', '~> 2.0.0-beta5'
+  s.dependency 'OTAcceleratorPackUtil', '~> 2.0.0'
 end

--- a/ios/ScreenShareAccPackKit/OTScreenShareKit/OTMultiPartyScreenSharer.h
+++ b/ios/ScreenShareAccPackKit/OTScreenShareKit/OTMultiPartyScreenSharer.h
@@ -7,34 +7,12 @@
 #import <Foundation/Foundation.h>
 #import "OTAcceleratorSession.h"
 #import "OTVideoView.h"
-
-typedef NS_ENUM(NSUInteger, OTMultiPartyScreenSharerSignal) {
-    OTPublisherCreated,
-    OTPublisherDestroyed,
-    OTSubscriberCreated,
-    OTSubscriberDestroyed,
-    OTSubscriberVideoDisabledByPublisher,
-    OTSubscriberVideoDisabledBySubscriber,
-    OTSubscriberVideoDisabledByBadQuality,
-    OTSubscriberVideoEnabledByPublisher,
-    OTSubscriberVideoEnabledBySubscriber,
-    OTSubscriberVideoEnabledByGoodQuality,
-    OTSubscriberVideoDisableWarning,
-    OTSubscriberVideoDisableWarningLifted,
-    OTMultiPartyScreenSharerError,
-    OTSessionDidBeginReconnecting,
-    OTSessionDidReconnect
-};
-
-typedef NS_ENUM(NSInteger, OTVideoViewContentMode) {
-    OTVideoViewFill,
-    OTVideoViewFit
-};
+#import "OTCommonCommunicator.h"
 
 @class OTMultiPartyScreenSharer;
 @class OTMultiPartyScreenShareRemote;
 
-typedef void (^OTMultiPartyScreenSharerBlock)(OTMultiPartyScreenSharerSignal signal, OTMultiPartyScreenShareRemote *subscriber, NSError *error);
+typedef void (^OTMultiPartyScreenSharerBlock)(OTCommunicationSignal signal, OTMultiPartyScreenShareRemote *subscriber, NSError *error);
 
 @protocol OTMultiPartyScreenSharerDataSource <NSObject>
 - (OTAcceleratorSession *)sessionOfOTMultiPartyScreenSharer:(OTMultiPartyScreenSharer *)multiPartyScreenSharer;

--- a/ios/ScreenShareAccPackKit/OTScreenShareKit/OTMultiPartyScreenSharer.h
+++ b/ios/ScreenShareAccPackKit/OTScreenShareKit/OTMultiPartyScreenSharer.h
@@ -87,11 +87,6 @@ typedef void (^OTMultiPartyScreenSharerBlock)(OTCommunicationSignal signal, OTMu
  */
 @property (nonatomic) AVCaptureDevicePosition cameraPosition;
 
-/**
- * Container of subscribers: instance of OTMultiPartyScreenShareRemote
- */
-@property (readonly, nonatomic) NSMutableArray *subscribers;
-
 @end
 
 @interface OTMultiPartyScreenShareRemote : NSObject

--- a/ios/ScreenShareAccPackKit/OTScreenShareKit/OTMultiPartyScreenSharer.h
+++ b/ios/ScreenShareAccPackKit/OTScreenShareKit/OTMultiPartyScreenSharer.h
@@ -56,6 +56,12 @@ typedef void (^OTMultiPartyScreenSharerBlock)(OTCommunicationSignal signal, OTMu
  */
 - (NSError *)disconnect;
 
+/**
+ *  A boolean value that indicates whether the specified UIView is sharing.
+ */
+@property (readonly, nonatomic) BOOL isCallEnabled;
+
+
 #pragma mark - publisher
 /**
  *  The view for this publisher. If this view becomes visible, it will display a preview of the active camera feed.
@@ -80,6 +86,11 @@ typedef void (^OTMultiPartyScreenSharerBlock)(OTCommunicationSignal signal, OTMu
  *  if the publisher has not yet begun publishing, getting this property returns the preferred camera position.
  */
 @property (nonatomic) AVCaptureDevicePosition cameraPosition;
+
+/**
+ * Container of subscribers: instance of OTMultiPartyScreenShareRemote
+ */
+@property (readonly, nonatomic) NSMutableArray *subscribers;
 
 @end
 

--- a/ios/ScreenShareAccPackKit/OTScreenShareKit/OTMultiPartyScreenSharer.m
+++ b/ios/ScreenShareAccPackKit/OTScreenShareKit/OTMultiPartyScreenSharer.m
@@ -295,7 +295,7 @@ static NSString* const KLogVariationFailure = @"Failure";
 }
 
 - (void)session:(OTSession *)session streamDestroyed:(OTStream *)stream {
-    for (OTMultiPartyScreenShareRemote *subscriberObject in _subscribers) {
+    for (OTMultiPartyScreenShareRemote *subscriberObject in self.subscribers) {
         if (subscriberObject.subscriber.stream == stream) {
             OTError *error = nil;
             OTSubscriber *subscriber = subscriberObject.subscriber;
@@ -349,15 +349,18 @@ static NSString* const KLogVariationFailure = @"Failure";
 - (void)subscriberDidConnectToStream:(OTSubscriber *)subscriber {
     
     OTMultiPartyScreenShareRemote *subscriberObject = [[OTMultiPartyScreenShareRemote alloc] initWithSubscriber:subscriber];
-    [_subscribers addObject:subscriberObject];
+    if (!self.subscribers) {
+        self.subscribers = [[NSMutableArray alloc] init];
+    }
+    [self.subscribers addObject:subscriberObject];
     [self notifiyAllWithSignal:OTSubscriberCreated subscriber:subscriberObject error:nil];
 }
 
 - (void)subscriberDidDisconnectFromStream:(OTSubscriber *)subscriber {
     
     OTMultiPartyScreenShareRemote *subscriberObject = [[OTMultiPartyScreenShareRemote alloc] initWithSubscriber:subscriber];
-    if ([_subscribers containsObject:subscriberObject]) {
-        [_subscribers removeObject:subscriberObject];
+    if ([self.subscribers containsObject:subscriberObject]) {
+        [self.subscribers removeObject:subscriberObject];
     }
     [self notifiyAllWithSignal:OTSubscriberDestroyed subscriber:subscriberObject error:nil];
 }

--- a/ios/ScreenShareAccPackKit/OTScreenShareKit/OTMultiPartyScreenSharer.m
+++ b/ios/ScreenShareAccPackKit/OTScreenShareKit/OTMultiPartyScreenSharer.m
@@ -188,7 +188,7 @@ static NSString* const KLogVariationFailure = @"Failure";
     self.handler = handler;
     NSError *error = [self connectWithView:view];
     if (error) {
-        self.handler(OTMultiPartyScreenSharerError, nil, error);
+        self.handler(OTCommunicationError, nil, error);
     }
 }
 
@@ -242,7 +242,7 @@ static NSString* const KLogVariationFailure = @"Failure";
     return disconnectError;
 }
 
-- (void)notifiyAllWithSignal:(OTMultiPartyScreenSharerSignal)signal
+- (void)notifiyAllWithSignal:(OTCommunicationSignal)signal
                   subscriber:(OTMultiPartyScreenShareRemote *)subscriber
                        error:(NSError *)error {
     
@@ -272,7 +272,7 @@ static NSString* const KLogVariationFailure = @"Failure";
     OTError *error;
     [self.session publish:self.publisher error:&error];
     if (error) {
-        [self notifiyAllWithSignal:OTMultiPartyScreenSharerError
+        [self notifiyAllWithSignal:OTCommunicationError
                         subscriber:nil
                              error:error];
     }
@@ -320,7 +320,7 @@ static NSString* const KLogVariationFailure = @"Failure";
 }
 
 - (void)session:(OTSession *)session didFailWithError:(OTError *)error {
-    [self notifiyAllWithSignal:OTMultiPartyScreenSharerError
+    [self notifiyAllWithSignal:OTCommunicationError
                     subscriber:nil
                          error:error];
 }
@@ -340,7 +340,7 @@ static NSString* const KLogVariationFailure = @"Failure";
 #pragma mark - OTPublisherDelegate
 - (void)publisher:(OTPublisherKit *)publisher didFailWithError:(OTError *)error {
     if (publisher == self.publisher) {
-        [self notifiyAllWithSignal:OTMultiPartyScreenSharerError
+        [self notifiyAllWithSignal:OTCommunicationError
                         subscriber:nil
                              error:error];
     }

--- a/ios/ScreenShareAccPackKit/OTScreenShareKit/OTScreenSharer.h
+++ b/ios/ScreenShareAccPackKit/OTScreenShareKit/OTScreenSharer.h
@@ -8,27 +8,6 @@
 #import "OTAcceleratorSession.h"
 #import "OTOneToOneCommunicator.h"
 
-typedef NS_ENUM(NSUInteger, OTScreenShareSignal) {
-    OTScreenSharePublisherCreated = 0,
-    OTScreenSharePublisherDestroyed,
-    OTScreenShareSubscriberCreated,
-    OTScreenShareSubscriberReady,
-    OTScreenShareSubscriberDestroyed,
-    OTScreenShareSubscriberVideoDisabledByPublisher,
-    OTScreenShareSubscriberVideoDisabledBySubscriber,
-    OTScreenShareSubscriberVideoDisabledByBadQuality,
-    OTScreenShareSubscriberVideoEnabledByPublisher,
-    OTScreenShareSubscriberVideoEnabledBySubscriber,
-    OTScreenShareSubscriberVideoEnabledByGoodQuality,
-    OTScreenShareSubscriberVideoDisableWarning,
-    OTScreenShareSubscriberVideoDisableWarningLifted,
-    OTScreenShareError,
-    OTScreenShareSessionDidBeginReconnecting,
-    OTScreenShareSessionDidReconnect
-};
-
-typedef void (^OTScreenShareBlock)(OTScreenShareSignal signal, NSError *error);
-
 @class OTScreenSharer;
 
 @protocol OTScreenShareDataSource <NSObject>
@@ -64,7 +43,7 @@ typedef void (^OTScreenShareBlock)(OTScreenShareSignal signal, NSError *error);
  *  @param handler The completion handler to call with the change.
  */
 - (void)connectWithView:(UIView *)view
-                handler:(OTScreenShareBlock)handler;
+                handler:(OTCommunicatorBlock)handler;
 
 /**
  *  De-registers to the shared session: [OTAcceleratorSession] and stops publishing/subscriber.
@@ -85,7 +64,7 @@ typedef void (^OTScreenShareBlock)(OTScreenShareSignal signal, NSError *error);
 
 #pragma mark - subscriber
 /**
- *  The scaling of the rendered video, as defined by the <OTScreenShareVideoViewContentMode> enum.
+ *  The scaling of the rendered video, as defined by the <OTVideoViewContentMode> enum.
  *  The default value is OTVideoViewScaleBehaviorFill. 
  *  Set it to OTVideoViewScaleBehaviorFit to have the video shrink, as needed, so that the entire video is visible(with pillarboxing).
  */
@@ -110,7 +89,7 @@ typedef void (^OTScreenShareBlock)(OTScreenShareSignal signal, NSError *error);
 /**
  *  The view containing a playback buffer for associated video data. Add this view to your view heirarchy to display a video stream.
  *
- *  The subscriber view is available after OTScreenShareSignalSubscriberDidConnect being signaled.
+ *  The subscriber view is available after OTSubscriberDidConnect being signaled.
  */
 @property (readonly, nonatomic) OTVideoView *subscriberView;
 
@@ -128,7 +107,7 @@ typedef void (^OTScreenShareBlock)(OTScreenShareSignal signal, NSError *error);
 /**
  *  The view for this publisher. If this view becomes visible, it will display a preview of the active screen share feed.
  *
- *  The publisher view is available after OTScreenShareSignalSessionDidConnect being signaled.
+ *  The publisher view is available after OTSessionDidConnect being signaled.
  */
 @property (readonly, nonatomic) OTVideoView *publisherView;
 

--- a/ios/ScreenShareAccPackKit/OTScreenShareKit/OTScreenSharer.m
+++ b/ios/ScreenShareAccPackKit/OTScreenShareKit/OTScreenSharer.m
@@ -55,7 +55,7 @@ static NSString * const KLogVariationFailure = @"Failure";
 @property (nonatomic) OTVideoView *publisherView;
 @property (nonatomic) OTVideoView *subscriberView;
 
-@property (strong, nonatomic) OTScreenShareBlock handler;
+@property (strong, nonatomic) OTCommunicatorBlock handler;
 
 @end
 
@@ -105,14 +105,14 @@ static NSString * const KLogVariationFailure = @"Failure";
 }
 
 - (void)connectWithView:(UIView *)view
-                handler:(OTScreenShareBlock)handler {
+                handler:(OTCommunicatorBlock)handler {
     
     if (!handler) return;
     
     self.handler = handler;
     NSError *error = [self connectWithView:view];
     if (error) {
-        self.handler(OTScreenShareError, error);
+        self.handler(OTCommunicationError, error);
     }
 }
 
@@ -163,7 +163,7 @@ static NSString * const KLogVariationFailure = @"Failure";
     }
 }
 
-- (void)notifiyAllWithSignal:(OTScreenShareSignal)signal error:(NSError *)error {
+- (void)notifiyAllWithSignal:(OTCommunicationSignal)signal error:(NSError *)error {
 
     if (self.handler) {
         self.handler(signal, error);
@@ -188,7 +188,7 @@ static NSString * const KLogVariationFailure = @"Failure";
     OTError *error;
     [self.session publish:self.publisher error:&error];
     if (error) {
-        [self notifiyAllWithSignal:OTScreenShareError
+        [self notifiyAllWithSignal:OTCommunicationError
                              error:error];
     }
     else {
@@ -197,13 +197,13 @@ static NSString * const KLogVariationFailure = @"Failure";
             self.publisherView = [OTVideoView defaultPlaceHolderImageWithPublisher:self.publisher];
             self.publisherView.delegate = self;
         }
-        [self notifiyAllWithSignal:OTScreenSharePublisherCreated
+        [self notifiyAllWithSignal:OTPublisherCreated
                              error:nil];
     }
 }
 
 - (void) sessionDidDisconnect:(OTSession *)session {
-    [self notifiyAllWithSignal:OTScreenSharePublisherDestroyed
+    [self notifiyAllWithSignal:OTPublisherDestroyed
                          error:nil];
 }
 
@@ -224,30 +224,30 @@ static NSString * const KLogVariationFailure = @"Failure";
         self.subscriber.viewScaleBehavior = OTVideoViewScaleBehaviorFill;
     }
     [self.session subscribe:self.subscriber error:&subscrciberError];
-    [self notifiyAllWithSignal:OTScreenShareSubscriberCreated error:subscrciberError];
+    [self notifiyAllWithSignal:OTSubscriberCreated error:subscrciberError];
 }
 
 - (void) session:(OTSession *)session streamDestroyed:(OTStream *)stream {
 
     if (self.subscriber.stream && [self.subscriber.stream.streamId isEqualToString:stream.streamId]) {
         [self cleanupSubscriber];
-        [self notifiyAllWithSignal:OTScreenShareSubscriberDestroyed
+        [self notifiyAllWithSignal:OTSubscriberDestroyed
                              error:nil];
     }
 }
 
 - (void)session:(OTSession *)session didFailWithError:(OTError *)error {
-    [self notifiyAllWithSignal:OTScreenShareError
+    [self notifiyAllWithSignal:OTCommunicationError
                          error:error];
 }
 
 - (void)sessionDidBeginReconnecting:(OTSession *)session {
-    [self notifiyAllWithSignal:OTScreenShareSessionDidBeginReconnecting
+    [self notifiyAllWithSignal:OTSessionDidBeginReconnecting
                          error:nil];
 }
 
 - (void)sessionDidReconnect:(OTSession *)session {
-    [self notifiyAllWithSignal:OTScreenShareSessionDidReconnect
+    [self notifiyAllWithSignal:OTSessionDidReconnect
                          error:nil];
 }
 
@@ -255,7 +255,7 @@ static NSString * const KLogVariationFailure = @"Failure";
 
 - (void)publisher:(OTPublisherKit *)publisher didFailWithError:(OTError *)error {
     if (publisher == self.publisher) {
-        [self notifiyAllWithSignal:OTScreenShareError
+        [self notifiyAllWithSignal:OTCommunicationError
                              error:error];
     }
 }
@@ -265,7 +265,7 @@ static NSString * const KLogVariationFailure = @"Failure";
     if (subscriber == self.subscriber) {
         _subscriberView = [OTVideoView defaultPlaceHolderImageWithSubscriber:self.subscriber];
         _subscriberView.delegate = self;
-        [self notifiyAllWithSignal:OTScreenShareSubscriberCreated
+        [self notifiyAllWithSignal:OTSubscriberCreated
                              error:nil];
     }
 }
@@ -274,16 +274,16 @@ static NSString * const KLogVariationFailure = @"Failure";
     if (subscriber != self.subscriber) return;
     
     if (reason == OTSubscriberVideoEventPublisherPropertyChanged) {
-        [self notifiyAllWithSignal:OTScreenShareSubscriberVideoDisabledByPublisher
+        [self notifiyAllWithSignal:OTSubscriberVideoDisabledByPublisher
                              error:nil];
     }
     else if (reason == OTSubscriberVideoEventSubscriberPropertyChanged) {
-        [self notifiyAllWithSignal:OTScreenShareSubscriberVideoDisabledBySubscriber
+        [self notifiyAllWithSignal:OTSubscriberVideoDisabledBySubscriber
                              error:nil];
     
     }
     else if (reason == OTSubscriberVideoEventQualityChanged) {
-        [self notifiyAllWithSignal:OTScreenShareSubscriberVideoDisabledByBadQuality
+        [self notifiyAllWithSignal:OTSubscriberVideoDisabledByBadQuality
                              error:nil];
     }
 }
@@ -292,36 +292,36 @@ static NSString * const KLogVariationFailure = @"Failure";
     if (subscriber != self.subscriber) return;
     
     if (reason == OTSubscriberVideoEventPublisherPropertyChanged) {
-        [self notifiyAllWithSignal:OTScreenShareSubscriberVideoEnabledByPublisher
+        [self notifiyAllWithSignal:OTSubscriberVideoEnabledByPublisher
                              error:nil];
     }
     else if (reason == OTSubscriberVideoEventSubscriberPropertyChanged) {
-        [self notifiyAllWithSignal:OTScreenShareSubscriberVideoEnabledBySubscriber
+        [self notifiyAllWithSignal:OTSubscriberVideoEnabledBySubscriber
                              error:nil];
     }
     else if (reason == OTSubscriberVideoEventQualityChanged) {
-        [self notifiyAllWithSignal:OTScreenShareSubscriberVideoEnabledByGoodQuality
+        [self notifiyAllWithSignal:OTSubscriberVideoEnabledByGoodQuality
                              error:nil];
     }
 }
 
 -(void) subscriberVideoDisableWarning:(OTSubscriber *)subscriber reason:(OTSubscriberVideoEventReason)reason {
     if (subscriber == self.subscriber) {
-        [self notifiyAllWithSignal:OTScreenShareSubscriberVideoDisableWarning
+        [self notifiyAllWithSignal:OTSubscriberVideoDisableWarning
                              error:nil];
     }
 }
 
 -(void) subscriberVideoDisableWarningLifted:(OTSubscriberKit *)subscriber reason:(OTSubscriberVideoEventReason)reason {
     if (subscriber == self.subscriber) {
-        [self notifiyAllWithSignal:OTScreenShareSubscriberVideoDisableWarningLifted
+        [self notifiyAllWithSignal:OTSubscriberVideoDisableWarningLifted
                              error:nil];
     }
 }
 
 - (void)subscriber:(OTSubscriberKit *)subscriber didFailWithError:(OTError *)error {
     if (subscriber == self.subscriber) {
-        [self notifiyAllWithSignal:OTScreenShareError
+        [self notifiyAllWithSignal:OTCommunicationError
                              error:error];
     }
 }


### PR DESCRIPTION
…creenSharerSignal and OTScreenShareSignal. (DRY principle)

Increment OTScreenShareKit to 2.0.0-beta5 and dependency OTAcceleratorPackUtil into 2.0.0-beta5.

This PR depends of the approval of OTAcceleratorPackUtil: opentok/acc-pack-common#65
